### PR TITLE
Fix an issue that the syncTimestampToDisplayLocked incorrect

### DIFF
--- a/services/camera/libcameraservice/device3/Camera3OutputStream.cpp
+++ b/services/camera/libcameraservice/device3/Camera3OutputStream.cpp
@@ -1522,7 +1522,8 @@ nsecs_t Camera3OutputStream::syncTimestampToDisplayLocked(nsecs_t t) {
                 vsyncTime.deadlineTimestamp >= currentTime &&
                 ((!cameraDisplayInSync && vsyncTime.expectedPresentationTime > minPresentT) ||
                  (cameraDisplayInSync && vsyncTime.expectedPresentationTime >
-                mLastPresentTime + minInterval + biasForShortDelay * kTimelineThresholdNs))) {
+                mLastPresentTime + minInterval +
+                    static_cast<nsecs_t>(biasForShortDelay * kTimelineThresholdNs)))) {
             expectedPresentT = vsyncTime.expectedPresentationTime;
             minDiff = std::abs(vsyncTime.expectedPresentationTime - idealPresentT);
         }


### PR DESCRIPTION
If the device turned on for a long time then the timestamp get biffer. In this case, the conversion error between float<->nsecs_t also becomes large enough to prevent the best timestamp selection. This causes frame drops when timestamps get large enough.

Bug: 263096067
Test: Manual test after device is turned on for long time
Google: 2361647
Change-Id: I94c90b32a053f7c0c0816dadbef8a47e13c64b30